### PR TITLE
Add debug build CI with Github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Build CI
+
+on:
+  - push
+  - pull_request
+
+env:
+  WARN_ON_PR: "artifact upload is disabled due to the workflow is trigged by pull request."
+
+jobs:
+  build:
+    name: Gradle CI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Clone repository
+
+    - name: Prepare Java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+        java-package: jdk+fx
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ hashFiles('**/*gradle*') }}
+        restore-keys: ${{ runner.os }}
+
+    - name: Build project
+      env:
+        DEBUG_KEY_PASSWORD: android
+        DEBUG_STORE_PASSWORD: android
+        DEBUG_KEY_ALIAS: androiddebugkey
+      run: |
+        if ${{ !!github.head_ref }}; then echo "::warning:: Gradle $WARN_ON_PR"; fi
+        gradle wrapper
+        bash gradlew assembleDebug
+    
+    - name: Upload articact
+      uses: actions/upload-artifact@v2
+      if: ${{ !github.head_ref }}
+      with:
+        path: app/build/outputs/apk
+        name: binary


### PR DESCRIPTION
[![Build CI](https://github.com/mnixry/UnblockMusicPro_Xposed/workflows/Build%20CI/badge.svg)](https://github.com/mnixry/UnblockMusicPro_Xposed/actions/runs/533215578)
使用Github Action的自动化CI, 在每次push时自动编译并上传debug版本的apk包
也可以对Pull Request进行检查, 并且考虑安全性, 不上传apk包